### PR TITLE
Return Network Response from API

### DIFF
--- a/app/src/main/java/org/codethechange/culturemesh/API.java
+++ b/app/src/main/java/org/codethechange/culturemesh/API.java
@@ -133,38 +133,38 @@ class API {
     }
 
     static class Post {
-        static void addUserToEvent(BigInteger userId, BigInteger eventId) {
-
+        static NetworkResponse addUserToEvent(BigInteger userId, BigInteger eventId) {
+            return new NetworkResponse();
         }
 
-        static void addUserToNetwork(BigInteger userId, BigInteger networkId) {
-
+        static NetworkResponse addUserToNetwork(BigInteger userId, BigInteger networkId) {
+            return new NetworkResponse();
         }
 
-        static void user(User user) {
-
+        static NetworkResponse user(User user) {
+            return new NetworkResponse();
         }
 
-        static void network(Network network) {
-
+        static NetworkResponse network(Network network) {
+            return new NetworkResponse();
         }
 
-        static void post(org.codethechange.culturemesh.models.Post post) {
-
+        static NetworkResponse post(org.codethechange.culturemesh.models.Post post) {
+            return new NetworkResponse();
         }
 
-        static void event(Event event) {
-
+        static NetworkResponse event(Event event) {
+            return new NetworkResponse();
         }
     }
 
     static class Put {
-        static void user(User user) {
-
+        static NetworkResponse user(User user) {
+            return new NetworkResponse();
         }
 
-        static void event(Event event) {
-
+        static NetworkResponse event(Event event) {
+            return new NetworkResponse();
         }
 
     }

--- a/app/src/main/java/org/codethechange/culturemesh/CreateEventActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/CreateEventActivity.java
@@ -1,5 +1,6 @@
 package org.codethechange.culturemesh;
 
+import android.app.Activity;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.os.AsyncTask;
@@ -32,6 +33,8 @@ public class CreateEventActivity extends AppCompatActivity {
     private EditText nameRef;
     private EditText addressRef;
     private EditText descriptionRef;
+
+    private Activity myActivity = this;
 
     /**
      * Initialize activity with saved state
@@ -347,21 +350,18 @@ public class CreateEventActivity extends AppCompatActivity {
     /**
      * AsyncTask class to handle network latency when POSTing event
      */
-    private class PostEvent extends AsyncTask<Event, Integer, Boolean> {
+    private class PostEvent extends AsyncTask<Event, Integer, NetworkResponse> {
 
         ProgressBar progressBar;
 
         /**
          * In the background, POST an event
          * @param events Arbitrary number of events, the first of which will be POSTed
-         * @return true if the POSTing succeeds (which is always right now)
+         * @return NetworkResponse containing the results of the network operation
          */
         @Override
-        protected Boolean doInBackground(Event... events) {
-            API.Post.event(events[0]);
-            // TODO: Return false if POSTing fails
-            // TODO: Have some way to check progress of API (.status() method returns float 0 to 1?)
-            return true;
+        protected NetworkResponse doInBackground(Event... events) {
+            return API.Post.event(events[0]);
         }
 
         /**
@@ -386,15 +386,20 @@ public class CreateEventActivity extends AppCompatActivity {
         }
 
         /**
-         * Closes the activity and returns the user to the previous screen
-         * @param aBoolean Status of doInBackground method that represents whether POSTing succeeded
+         * If POSTing succeeded: Closes the activity and returns the user to the previous screen
+         * If POSTing failed: Displays error dialog and returns user to composing screen
+         * @param response Status of doInBackground method that represents whether POSTing succeeded
          */
         @Override
-        protected void onPostExecute(Boolean aBoolean) {
-            super.onPostExecute(aBoolean);
+        protected void onPostExecute(NetworkResponse response) {
+            super.onPostExecute(response);
             // SOURCE: https://stackoverflow.com/questions/4038479/android-go-back-to-previous-activity
-            finish();
+            if (response.fail()) {
+                response.showErrorDialog(myActivity);
+                progressBar.setIndeterminate(false);
+            } else {
+                finish();
+            }
         }
     }
-
 }

--- a/app/src/main/java/org/codethechange/culturemesh/CreatePostActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/CreatePostActivity.java
@@ -3,6 +3,7 @@ package org.codethechange.culturemesh;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Typeface;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
@@ -29,8 +30,10 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import org.codethechange.culturemesh.models.Event;
 import org.codethechange.culturemesh.models.Network;
 import org.codethechange.culturemesh.models.Post;
 import org.codethechange.culturemesh.models.User;
@@ -109,8 +112,9 @@ public class CreatePostActivity extends AppCompatActivity implements
                 User user = API.Get.user(new BigInteger("11"));
                 String contentHTML = Html.toHtml(content.getText());
                 String datePosted = new Date().toString();
-                API.Post.post(new Post(user, contentHTML, datePosted));
-                finish();
+
+                Post newPost = new Post(user, contentHTML, datePosted);
+                new PostPost().execute(newPost);
             }
         });
     }
@@ -280,6 +284,46 @@ public class CreatePostActivity extends AppCompatActivity implements
                 //Update icon!
                 item.setIcon(toggleIcons.get(id)[iconIndex]);
             }
+        }
+    }
+
+    /**
+     * AsyncTask class to handle network latency when POSTing post
+     */
+    private class PostPost extends AsyncTask<Post, Integer, Boolean> {
+
+        ProgressBar progressBar;
+
+        /**
+         * In the background, POST the provided post
+         * @param posts List of posts, the first of which will be POSTed
+         * @return true if POSTing succeeded, false otherwise
+         */
+        @Override
+        protected Boolean doInBackground(Post... posts) {
+            API.Post.post(posts[0]);
+            // TODO: Return false if POSTing fails
+            return true;
+        }
+
+        /**
+         * Makes the progress bar indeterminate
+         */
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            progressBar = findViewById(R.id.postPostProgressBar);
+            progressBar.setIndeterminate(true); // Only because cannot get status from API
+        }
+
+        /**
+         * Closes the activity and returns the user to the previous screen
+         * @param aBoolean Status of doInBackground method that represents whether POSTing succeeded
+         */
+        @Override
+        protected void onPostExecute(Boolean aBoolean) {
+            super.onPostExecute(aBoolean);
+            finish();
         }
     }
 }

--- a/app/src/main/java/org/codethechange/culturemesh/NetworkResponse.java
+++ b/app/src/main/java/org/codethechange/culturemesh/NetworkResponse.java
@@ -1,0 +1,123 @@
+package org.codethechange.culturemesh;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.support.v7.app.AlertDialog;
+
+import java.util.Random;
+
+/**
+ * Class to store responses after attempting networking tasks
+ */
+public class NetworkResponse {
+    private boolean fail;
+    private int messageID;
+    private Object payload;
+
+    // TODO: Remove this testing-only constructor
+    /**
+     * Constructor that randomly chooses a failure state and a generic message based on that state
+     */
+    public NetworkResponse() {
+        Random r = new Random();
+        fail = r.nextBoolean();
+        if (fail)
+            messageID = R.string.genericFail;
+        else
+            messageID = R.string.genericSuccess;
+    }
+
+    /**
+     * Constructor that creates a generic message based on "inFail"
+     * @param inFail Failure state provided by user (true if failed)
+     */
+    public NetworkResponse(boolean inFail) {
+        fail = inFail;
+        if (inFail)
+            messageID = R.string.genericFail;
+        else
+            messageID = R.string.genericSuccess;
+    }
+
+    /**
+     * Constructor that sets message and failures state based on arguments
+     * @param inFail Failure state provided by user (true if failed)
+     * @param inMessageID ID for string resource containing message
+     */
+    public NetworkResponse(boolean inFail, int inMessageID) {
+        fail = inFail;
+        messageID = inMessageID;
+    }
+
+    /**
+     * Constructor that stores a payload and sets the failure state to false
+     * @param inPayload Payload returned by networking request
+     */
+    public NetworkResponse(Object inPayload) {
+        payload = inPayload;
+        fail = false;
+    }
+
+    /**
+     * Constructor that both stores a payload and sets the failure state from parameters
+     * @param inFail Whether or not the network operation failed
+     * @param inPayload Payload returned by networking request
+     */
+    public NetworkResponse(boolean inFail, Object inPayload) {
+        payload = inPayload;
+        fail = inFail;
+    }
+
+    /**
+     * Check whether the network request failed
+     * @return true if the request failed, false if it succeeded
+     */
+    public boolean fail() {
+        return fail;
+    }
+
+    /**
+     * Get the resource ID of the message to display to the user
+     * @return Resource ID of message
+     */
+    public int getMessageID() {
+        return messageID;
+    }
+
+    /**
+     * Get an error dialog that can be displayed to show message from messageID to user
+     * @param context Context upon which to display error dialog
+     * @return Dialog that can be shown
+     */
+    public AlertDialog getErrorDialog(Context context) {
+        // SOURCE: https://stackoverflow.com/questions/26097513/android-simple-alert-dialog
+        AlertDialog errDialog = new AlertDialog.Builder(context).create();
+        errDialog.setTitle(context.getString(R.string.error));
+        errDialog.setMessage(context.getString(messageID));
+        DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        };
+        errDialog.setButton(AlertDialog.BUTTON_NEUTRAL, context.getString(R.string.ok), listener);
+        return errDialog;
+    }
+
+    /**
+     * Show an error dialog that can be displayed to show message from messageID to user
+     * @param context Context upon which to display error dialog
+     */
+    public void showErrorDialog(Context context) {
+        AlertDialog errDialog = getErrorDialog(context);
+        errDialog.show();
+    }
+
+    /**
+     * Get the payload returned by the network operation
+     * @return Payload returned by network operation
+     */
+    public Object getPayload() {
+        // TODO: This should throw an exception if payload is undefined
+        return payload;
+    }
+}

--- a/app/src/main/res/layout/content_create_post.xml
+++ b/app/src/main/res/layout/content_create_post.xml
@@ -58,4 +58,15 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/postPostProgressBar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginStart="@dimen/ui_element_horizontal_spacing"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,4 +77,8 @@
     <string name="first_name">First Name</string>
     <string name="last_name">Last Name</string>
     <string name="confirm_password">Confirm Password</string>
+
+    <string name="error">Error</string>
+    <string name="genericFail">Oops, something went wrong.</string>
+    <string name="genericSuccess">Operation Succeeded!</string>
 </resources>


### PR DESCRIPTION
Create a NetworkResponse class to hold responses from API calls for network operations. Class records success/failures status for each operation and can pass messages and object payloads. Messages are for holding error messages, and object payloads are for returning objects from GET calls.