### PR TITLE
Make Start Screen Explore if User Has No Networks

### DIFF
--- a/app/src/main/java/org/codethechange/bubblepicker/rendering/BubblePicker.kt
+++ b/app/src/main/java/org/codethechange/bubblepicker/rendering/BubblePicker.kt
@@ -68,7 +68,7 @@ class BubblePicker : GLSurfaceView {
 
     constructor(context: Context?) : this(context, null)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {
-        setZOrderOnTop(true)
+        setZOrderOnTop(false)
         setEGLContextClientVersion(2)
         setEGLConfigChooser(8, 8, 8, 8, 16, 0)
         holder.setFormat(PixelFormat.RGBA_8888)

--- a/app/src/main/java/org/codethechange/culturemesh/API.java
+++ b/app/src/main/java/org/codethechange/culturemesh/API.java
@@ -20,6 +20,7 @@ class API {
     static final String SETTINGS_IDENTIFIER = "acmsi";
     static final String PERSONAL_NETWORKS = "pernet";
     static final String SELECTED_NETWORK = "selnet";
+    static final boolean NO_JOINED_NETWORKS = true;
 
 
     //TODO: REMOVE DUMMY GENERATORS

--- a/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
@@ -69,10 +69,26 @@ private String basePath = "www.culturemesh.com/api/v1";
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_timeline);
 
+        setContentView(R.layout.activity_timeline);
         settings = getSharedPreferences(API.SETTINGS_IDENTIFIER, MODE_PRIVATE);
 
+        getSupportActionBar().setLogo(R.drawable.logo_header);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+
+        if (API.NO_JOINED_NETWORKS) {
+            createNoNetwork();
+        } else {
+            createDefaultNetwork();
+        }
+    }
+
+    protected void createNoNetwork() {
+        Intent startExplore = new Intent(getApplicationContext(), ExploreBubblesOpenGLActivity.class);
+        startActivity(startExplore);
+    }
+
+    protected void createDefaultNetwork() {
         /* //Set up Toolbar
         Toolbar mToolbar = (Toolbar) findViewById(R.id.action_bar);
         setSupportActionBar(mToolbar);
@@ -91,7 +107,6 @@ private String basePath = "www.culturemesh.com/api/v1";
 
 
         //Choose selected network.
-        //TODO: Create better default behavior for no selected networks.
         String selectedNetwork = settings.getString(API.SELECTED_NETWORK, "123456");
         BigInteger id = new BigInteger(selectedNetwork);
         network = API.Get.network(id);

--- a/app/src/main/res/layout/activity_explore_bubbles_open_gl.xml
+++ b/app/src/main/res/layout/activity_explore_bubbles_open_gl.xml
@@ -24,12 +24,4 @@
 
     <include layout="@layout/content_explore_bubbles_open_gl" />
 
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/fab_margin"
-        app:srcCompat="@android:drawable/ic_dialog_email" />
-
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
If a user has not joined any networks, show the explore page when the app starts. This PR also makes the bubbles in explore show up behind the navigation drawer when it is open so they do not impede its use.