### PR TITLE
Pick onboarding status

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,16 +13,11 @@
             android:name=".TimelineActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".ExploreBubblesOpenGLActivity"
             android:label="@string/title_activity_explore_bubbles_open_gl"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".FindNetworkActivity"
             android:label="@string/title_activity_find_network"
@@ -74,7 +69,17 @@
             android:name=".LoginActivity"
             android:label="@string/title_activity_login"
             android:parentActivityName=".TimelineActivity"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+            android:theme="@style/AppTheme.NoActionBar" />
+        <activity
+            android:name=".PickOnboardingStatusActivity"
+            android:label="@string/title_activity_pick_onboarding_status"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/org/codethechange/culturemesh/PickOnboardingStatusActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/PickOnboardingStatusActivity.java
@@ -1,0 +1,36 @@
+package org.codethechange.culturemesh;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.design.widget.FloatingActionButton;
+import android.support.design.widget.Snackbar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.View;
+
+public class PickOnboardingStatusActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_pick_onboarding_status);
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+    }
+
+    public void tapReturning(View v) {
+        Intent start = new Intent(getApplicationContext(), TimelineActivity.class);
+        startActivity(start);
+    }
+
+    public void tapNew(View v) {
+        Intent start = new Intent(getApplicationContext(), LoginActivity.class);
+        startActivity(start);
+    }
+
+    public void tapNoNetworks(View v) {
+        Intent start = new Intent(getApplicationContext(), ExploreBubblesOpenGLActivity.class);
+        startActivity(start);
+    }
+
+}

--- a/app/src/main/java/org/codethechange/culturemesh/PickOnboardingStatusActivityFragment.java
+++ b/app/src/main/java/org/codethechange/culturemesh/PickOnboardingStatusActivityFragment.java
@@ -1,0 +1,22 @@
+package org.codethechange.culturemesh;
+
+import android.support.v4.app.Fragment;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A placeholder fragment containing a simple view.
+ */
+public class PickOnboardingStatusActivityFragment extends Fragment {
+
+    public PickOnboardingStatusActivityFragment() {
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_pick_onboarding_status, container, false);
+    }
+}

--- a/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
@@ -75,17 +75,7 @@ private String basePath = "www.culturemesh.com/api/v1";
 
         getSupportActionBar().setLogo(R.drawable.logo_header);
         getSupportActionBar().setDisplayShowTitleEnabled(false);
-
-        if (API.NO_JOINED_NETWORKS) {
-            createNoNetwork();
-        } else {
-            createDefaultNetwork();
-        }
-    }
-
-    protected void createNoNetwork() {
-        Intent startExplore = new Intent(getApplicationContext(), ExploreBubblesOpenGLActivity.class);
-        startActivity(startExplore);
+        createDefaultNetwork();
     }
 
     protected void createDefaultNetwork() {

--- a/app/src/main/res/layout/activity_pick_onboarding_status.xml
+++ b/app/src/main/res/layout/activity_pick_onboarding_status.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.codethechange.culturemesh.PickOnboardingStatusActivity">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <include layout="@layout/content_pick_onboarding_status" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_pick_onboarding_status.xml
+++ b/app/src/main/res/layout/content_pick_onboarding_status.xml
@@ -1,0 +1,9 @@
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragment"
+    android:name="org.codethechange.culturemesh.PickOnboardingStatusActivityFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:layout="@layout/fragment_pick_onboarding_status" />

--- a/app/src/main/res/layout/fragment_pick_onboarding_status.xml
+++ b/app/src/main/res/layout/fragment_pick_onboarding_status.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.codethechange.culturemesh.PickOnboardingStatusActivityFragment"
+    tools:showIn="@layout/activity_pick_onboarding_status">
+
+    <Button
+        android:id="@+id/pickOnboarding_returning"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginStart="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginTop="@dimen/ui_element_vertical_spacing"
+        android:text="Returning User"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:onClick="tapReturning"/>
+
+    <Button
+        android:id="@+id/pickOnboarding_new"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginStart="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginTop="@dimen/ui_element_vertical_spacing"
+        android:text="New Installation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/pickOnboarding_returning"
+        android:onClick="tapNew"/>
+
+    <Button
+        android:id="@+id/pickOnboarding_noNetworks"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginStart="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginTop="@dimen/ui_element_vertical_spacing"
+        android:text="No Networks Joined"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/pickOnboarding_new"
+        android:onClick="tapNoNetworks"/>
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/menu_pick_onboarding_status.xml
+++ b/app/src/main/res/menu/menu_pick_onboarding_status.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="org.codethechange.culturemesh.PickOnboardingStatusActivity">
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="100"
+        android:title="@string/action_settings"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,4 +81,5 @@
     <string name="error">Error</string>
     <string name="genericFail">Oops, something went wrong.</string>
     <string name="genericSuccess">Operation Succeeded!</string>
+    <string name="title_activity_pick_onboarding_status">PickOnboardingStatusActivity</string>
 </resources>


### PR DESCRIPTION
Create a new activity that is shows when the app starts up. This activity is for testing, and allows testers to choose whether they want to test user onboarding. This replaces the logic from TimelineActivity that required a code change to test different onboarding scenarios.