### PR TITLE
Create Infrastructure for Specifying Next Activity to Launch

### DIFF
--- a/app/src/main/java/org/codethechange/culturemesh/API.java
+++ b/app/src/main/java/org/codethechange/culturemesh/API.java
@@ -52,7 +52,7 @@ class API {
     static final String SETTINGS_IDENTIFIER = "acmsi";
     static final String PERSONAL_NETWORKS = "pernet";
     static final String SELECTED_NETWORK = "selnet";
-    static final boolean NO_JOINED_NETWORKS = false;
+    static final String CURRENT_USER = "curruser";
     static CMDatabase mDb;
     //reqCounter to ensure that we don't close the database while another thread is using it.
     static int reqCounter;

--- a/app/src/main/java/org/codethechange/culturemesh/ApiUtils.java
+++ b/app/src/main/java/org/codethechange/culturemesh/ApiUtils.java
@@ -12,8 +12,22 @@ import java.util.concurrent.ExecutionException;
  */
 
 public class ApiUtils {
-    public static NetworkResponse<ArrayList<Network>> getJoinedNetworks(long currUser) {
-        AsyncTask<Long, Void, NetworkResponse<ArrayList<Network>>> task = new checkJoinedNetworks();
+
+    private static final String CURRENT_USER_BUNDLE_ID = "currUser";
+    private static final String APPLICATION_CONTEXT_BUNDLE_ID = "currUser";
+
+    public static boolean hasJoinedNetwork(
+            long currUser, AsyncTask<Long, Void, NetworkResponse<ArrayList<Network>>> task) {
+        NetworkResponse<ArrayList<Network>> response = getJoinedNetworks(currUser, task);
+        if (response.fail() || response.getPayload().isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static NetworkResponse<ArrayList<Network>> getJoinedNetworks(
+            long currUser, AsyncTask<Long, Void, NetworkResponse<ArrayList<Network>>> task) {
         task.execute(currUser);
         NetworkResponse<ArrayList<Network>> result;
         try {
@@ -24,19 +38,5 @@ public class ApiUtils {
             result = new NetworkResponse<>(true);
         }
         return result;
-    }
-
-    private static class checkJoinedNetworks extends AsyncTask<Long, Void, NetworkResponse<ArrayList<Network>>> {
-        @Override
-        protected NetworkResponse<ArrayList<Network>> doInBackground(Long... longs) {
-            long currUser = longs[0];
-            NetworkResponse<ArrayList<Network>> responseNetworks = API.Get.userNetworks(currUser);
-            return responseNetworks;
-        }
-
-        @Override
-        protected void onPostExecute(NetworkResponse<ArrayList<Network>> arrayListNetworkResponse) {
-            super.onPostExecute(arrayListNetworkResponse);
-        }
     }
 }

--- a/app/src/main/java/org/codethechange/culturemesh/ApiUtils.java
+++ b/app/src/main/java/org/codethechange/culturemesh/ApiUtils.java
@@ -1,0 +1,42 @@
+package org.codethechange.culturemesh;
+
+import android.os.AsyncTask;
+
+import org.codethechange.culturemesh.models.Network;
+
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Created by cs on 3/28/18.
+ */
+
+public class ApiUtils {
+    public static NetworkResponse<ArrayList<Network>> getJoinedNetworks(long currUser) {
+        AsyncTask<Long, Void, NetworkResponse<ArrayList<Network>>> task = new checkJoinedNetworks();
+        task.execute(currUser);
+        NetworkResponse<ArrayList<Network>> result;
+        try {
+            result = task.get();
+        } catch (InterruptedException e) {
+            result = new NetworkResponse<>(true);
+        } catch (ExecutionException e) {
+            result = new NetworkResponse<>(true);
+        }
+        return result;
+    }
+
+    private static class checkJoinedNetworks extends AsyncTask<Long, Void, NetworkResponse<ArrayList<Network>>> {
+        @Override
+        protected NetworkResponse<ArrayList<Network>> doInBackground(Long... longs) {
+            long currUser = longs[0];
+            NetworkResponse<ArrayList<Network>> responseNetworks = API.Get.userNetworks(currUser);
+            return responseNetworks;
+        }
+
+        @Override
+        protected void onPostExecute(NetworkResponse<ArrayList<Network>> arrayListNetworkResponse) {
+            super.onPostExecute(arrayListNetworkResponse);
+        }
+    }
+}

--- a/app/src/main/java/org/codethechange/culturemesh/LoginActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/LoginActivity.java
@@ -17,7 +17,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 
-public class LoginActivity extends AppCompatActivity {
+public class LoginActivity extends RedirectableAppCompatActivity {
     private boolean signInToggle = true;
     EditText firstNameText;
     EditText lastNameText;
@@ -177,20 +177,4 @@ public class LoginActivity extends AppCompatActivity {
             }
         });
     }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        if (isFinishing()) {
-            if (getIntent().hasExtra(Redirection.LAUNCH_ON_FINISH_EXTRA)) {
-                Class<?> nextActivity = (Class) getIntent().getSerializableExtra(Redirection.LAUNCH_ON_FINISH_EXTRA);
-                Intent next = new Intent(getApplicationContext(), nextActivity);
-                if (getIntent().hasExtra(Redirection.PASS_ON_FINISH_EXTRA)) {
-                    next.putExtras(getIntent().getBundleExtra(Redirection.PASS_ON_FINISH_EXTRA));
-                }
-            }
-        }
-
-    }
-
 }

--- a/app/src/main/java/org/codethechange/culturemesh/LoginActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/LoginActivity.java
@@ -2,6 +2,7 @@ package org.codethechange.culturemesh;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.constraint.ConstraintLayout;
 import android.support.constraint.ConstraintSet;
@@ -38,6 +39,13 @@ public class LoginActivity extends AppCompatActivity {
                 //TODO: Handle sign in.
                 Intent returnIntent = new Intent();
                 // TODO: Change result returned to RESULT_CANCELLED for no login
+                // Set the current user in the SharedPreferences settings to the user that just logged in
+                SharedPreferences settings = getSharedPreferences(API.SETTINGS_IDENTIFIER, MODE_PRIVATE);
+                SharedPreferences.Editor editor = settings.edit();
+                // TODO: Update the "1" here with the correct user ID
+                editor.putLong(API.CURRENT_USER, 1);
+                editor.apply();
+
                 setResult(Activity.RESULT_OK, returnIntent);
                 finish();
             }
@@ -168,6 +176,21 @@ public class LoginActivity extends AppCompatActivity {
                 }
             }
         });
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (isFinishing()) {
+            if (getIntent().hasExtra(Redirection.LAUNCH_ON_FINISH_EXTRA)) {
+                Class<?> nextActivity = (Class) getIntent().getSerializableExtra(Redirection.LAUNCH_ON_FINISH_EXTRA);
+                Intent next = new Intent(getApplicationContext(), nextActivity);
+                if (getIntent().hasExtra(Redirection.PASS_ON_FINISH_EXTRA)) {
+                    next.putExtras(getIntent().getBundleExtra(Redirection.PASS_ON_FINISH_EXTRA));
+                }
+            }
+        }
+
     }
 
 }

--- a/app/src/main/java/org/codethechange/culturemesh/RedirectableAppCompatActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/RedirectableAppCompatActivity.java
@@ -1,0 +1,25 @@
+package org.codethechange.culturemesh;
+
+import android.content.Intent;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * Created by cs on 3/28/18.
+ */
+
+public abstract class RedirectableAppCompatActivity extends AppCompatActivity {
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (isFinishing()) {
+            if (getIntent().hasExtra(Redirection.LAUNCH_ON_FINISH_EXTRA)) {
+                Class<?> nextActivity = (Class) getIntent().getSerializableExtra(Redirection.LAUNCH_ON_FINISH_EXTRA);
+                Intent next = new Intent(getApplicationContext(), nextActivity);
+                if (getIntent().hasExtra(Redirection.PASS_ON_FINISH_EXTRA)) {
+                    next.putExtras(getIntent().getBundleExtra(Redirection.PASS_ON_FINISH_EXTRA));
+                }
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/org/codethechange/culturemesh/Redirection.java
+++ b/app/src/main/java/org/codethechange/culturemesh/Redirection.java
@@ -1,0 +1,17 @@
+package org.codethechange.culturemesh;
+
+/**
+ * Created by cs on 3/28/18.
+ */
+
+public class Redirection {
+    /**
+     * When creating intents, extras with these keys can be used to pass information to the
+     * Activity being launched regarding what to do when the Activity finishes
+     */
+
+    // The Class<?> of the Activity to launch when finishing
+    static final String LAUNCH_ON_FINISH_EXTRA = "launchOnFinish";
+    // A Bundle whose contents will be passed as extras via the Intent called on finishing
+    static final String PASS_ON_FINISH_EXTRA = "passOnFinish";
+}

--- a/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
@@ -38,6 +38,7 @@ import org.codethechange.culturemesh.models.NearLocation;
 import org.codethechange.culturemesh.models.Network;
 import org.codethechange.culturemesh.models.User;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TimelineActivity extends DrawerActivity {
@@ -69,7 +70,8 @@ private String basePath = "www.culturemesh.com/api/v1";
         fromLocation = findViewById(R.id.fromLocation);
         nearLocation = findViewById(R.id.nearLocation);
         API.loadAppDatabase(getApplicationContext());
-        if (API.NO_JOINED_NETWORKS) {
+        long currUser = settings.getLong(API.CURRENT_USER, 1);
+        if (ApiUtils.hasJoinedNetwork(currUser, new checkJoinedNetworks())) {
             createNoNetwork();
         } else {
             createDefaultNetwork();
@@ -405,5 +407,19 @@ private String basePath = "www.culturemesh.com/api/v1";
         List<User> netUsers;
     }
 
+    private class checkJoinedNetworks extends AsyncTask<Long, Void, NetworkResponse<ArrayList<Network>>> {
+        @Override
+        protected NetworkResponse<ArrayList<Network>> doInBackground(Long... longs) {
+            API.loadAppDatabase(getApplicationContext());
+            long currUser = longs[0];
+            NetworkResponse<ArrayList<Network>> responseNetworks = API.Get.userNetworks(currUser);
+            return responseNetworks;
+        }
 
+        @Override
+        protected void onPostExecute(NetworkResponse<ArrayList<Network>> arrayListNetworkResponse) {
+            super.onPostExecute(arrayListNetworkResponse);
+            API.closeDatabase();
+        }
+    }
 }


### PR DESCRIPTION
Setup the foundation needed to specify via an Intent which Activity should be launched after the Intent's Activity finishes. An abstract class `RedirectableAppCompatActivity` is created which, when extended, gives its children an `onDestroy` method which checks the Intent Extras for information on which Activity to launch next.

Update `OnboardActivity` and `TimelineActivity` to use the API to check whether a user has joined any networks, and put the common code for that check in a new static class `ApiUtils`.