### PR TITLE
Check Joined Networks Via List Instead of API

### DIFF
--- a/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
@@ -93,10 +93,10 @@ private String basePath = "www.culturemesh.com/api/v1";
         fromLocation = findViewById(R.id.fromLocation);
         nearLocation = findViewById(R.id.nearLocation);
         long currUser = settings.getLong(API.CURRENT_USER, 1);
-        if (ApiUtils.hasJoinedNetwork(currUser, new checkJoinedNetworks())) {
-            createDefaultNetwork();
-        } else {
+        if (subscribedNetworks.size() == 0) {
             createNoNetwork();
+        } else {
+            createDefaultNetwork();
         }
 
         //TODO: For first run, uncomment this: new TestDatabase().execute();


### PR DESCRIPTION
Replace API call (via `hasJoinedNetwork`) with checking size of `subscribedNetworks` to determine
if user has joined any networks