### PR TITLE
Redirect Auth Error to Login

### DIFF
--- a/app/src/main/java/org/codethechange/culturemesh/API.java
+++ b/app/src/main/java/org/codethechange/culturemesh/API.java
@@ -132,7 +132,7 @@ class API {
      * Tag to use for log statements. It is set dynamically so that if the class name is refactored,
      * the logging tag will be too.
      */
-    private static final String TAG = API.class.getName();
+    private static final String TAG = API.class.getSimpleName();
 
     /**
      * Database to use for data persistence. Not currently used.
@@ -1080,8 +1080,8 @@ class API {
                     @Override
                     public void onResponse(NetworkResponse<LoginResponse> response) {
                         if (response.fail()) {
-                            listener.onResponse(new NetworkResponse<String>(true,
-                                    response.getMessageID()));
+                            NetworkResponse<String> nr = new NetworkResponse<>(response);
+                            listener.onResponse(nr);
                         } else {
                             loginToken = response.getPayload().token;
                             tokenRetrieved = Calendar.getInstance();
@@ -1152,9 +1152,11 @@ class API {
                     try {
                         int code = error.networkResponse.statusCode;
                         if (code == 401) {
-                            Log.d(TAG, "Authentication failure with 401 error when logging in" +
+                            Log.d(TAG, "Authentication failure with 401 error when logging in " +
                                     "with credentials.");
-                            listener.onResponse(NetworkResponse.getAuthFailed(R.string.authenticationError));
+                            NetworkResponse<LoginResponse> nr = new NetworkResponse<>(true, R.string.authenticationError);
+                            nr.setAuthFailed(true);
+                            listener.onResponse(nr);
                         } else {
                             int messageID = processNetworkError("API.Get.loginToken",
                                     "ErrorListener", error);
@@ -1240,7 +1242,7 @@ class API {
                 @Override
                 public void onResponse(NetworkResponse<String> response) {
                     if (response.fail()) {
-                        listener.onResponse(new NetworkResponse<String>(true, response.getMessageID()));
+                        listener.onResponse(new NetworkResponse<String>(response));
                     } else {
                         final String token = response.getPayload();
                         StringRequest req = new StringRequest(Request.Method.POST, url, new Response.Listener<String>() {
@@ -1371,15 +1373,16 @@ class API {
             Get.loginToken(queue, new Response.Listener<NetworkResponse<String>>() {
                 @Override
                 public void onResponse(NetworkResponse<String> response) {
+                    Log.d(TAG, logTag + " (via Post.model()): Response=" + response);
                     if (response.fail()) {
-                        listener.onResponse(new NetworkResponse<String>(true, response.getMessageID()));
+                        listener.onResponse(new NetworkResponse<String>(response));
                     } else {
                         final String token = response.getPayload();
                         StringRequest req = new StringRequest(Request.Method.POST, url,
                                 new Response.Listener<String>() {
                                     @Override
                                     public void onResponse(String response) {
-                                        listener.onResponse(new NetworkResponse<String>(false, response));
+                                        listener.onResponse(new NetworkResponse<>(false, response));
                                     }
                                 }, new Response.ErrorListener() {
                             @Override
@@ -1437,7 +1440,7 @@ class API {
                 @Override
                 public void onResponse(NetworkResponse<String> response) {
                     if (response.fail()) {
-                        listener.onResponse(new NetworkResponse<String>(true, response.getMessageID()));
+                        listener.onResponse(new NetworkResponse<String>(response));
                     } else {
                         final String token = response.getPayload();
                         StringRequest req = new StringRequest(Request.Method.PUT, API_URL_BASE +
@@ -1542,7 +1545,7 @@ class API {
                 @Override
                 public void onResponse(NetworkResponse<String> response) {
                     if (response.fail()) {
-                        listener.onResponse(new NetworkResponse<String>(true, response.getMessageID()));
+                        listener.onResponse(new NetworkResponse<String>(response));
                     } else {
                         final String token = response.getPayload();
                         StringRequest req = new StringRequest(Request.Method.PUT, url,

--- a/app/src/main/java/org/codethechange/culturemesh/NetworkResponse.java
+++ b/app/src/main/java/org/codethechange/culturemesh/NetworkResponse.java
@@ -41,6 +41,25 @@ public class NetworkResponse<E> {
     private boolean isAuthFailed;
 
     /**
+     * Create a new NetworkResponse of the type designated in {@code <>} from another NetworkResponse
+     * of any other type. Any payload in the source object will not be transferred to the created one.
+     * All other fields are copied.
+     * @param toConvert Source to create new object from. All properties except payload will be
+     *                  copied.
+     */
+    public NetworkResponse(NetworkResponse<?> toConvert) {
+        if (!toConvert.fail()) {
+            throw new IllegalArgumentException("The provided NetworkResponse Object to convert (" +
+                    toConvert + ") is not failed. NetworkResponse(NetworkResponse<Object>) requires" +
+                    "an argument NetworkResponse that is failed because the payload is dropped.");
+        }
+        Log.d(TAG, "Creating new NetworkResponse from " + toConvert.toString());
+        fail = toConvert.fail();
+        messageID = toConvert.getMessageID();
+        isAuthFailed = toConvert.isAuthFailed();
+    }
+
+    /**
      * Constructor that creates a generic message based on "inFail"
      * @param inFail Failure state provided by user (true if failed)
      */
@@ -107,6 +126,11 @@ public class NetworkResponse<E> {
         this.messageID = messageID;
     }
 
+    /**
+     * Get a {@link String} describing the type of the provided payload
+     * @param payload Payload whose type will be described. Can be null.
+     * @return {@code null} if the payload is null, the name of the payload's class otherwise
+     */
     private String payloadType(E payload) {
         String payloadType;
         if (payload == null) {
@@ -117,6 +141,11 @@ public class NetworkResponse<E> {
         return payloadType;
     }
 
+    /**
+     * Get a {@link String} describing the provided payload
+     * @param payload Payload which will be described. Can be null.
+     * @return {@code null} if the payload is null, the {@code payload.toString()} otherwise.
+     */
     private String payloadName(E payload) {
         String payloadName;
         if (payload == null) {
@@ -141,6 +170,25 @@ public class NetworkResponse<E> {
         NetworkResponse<API.Get.LoginResponse> nr = new NetworkResponse<>(true, messageID);
         nr.isAuthFailed = true;
         return nr;
+    }
+
+    /**
+     * Get whether the current object represents a failed authentication
+     * @return {@code true} if object represents an authentication failure, {@code false} otherwise
+     */
+    public boolean isAuthFailed() {
+        Log.d(TAG, "Returning isAuthFailed=" + isAuthFailed);
+        return isAuthFailed;
+    }
+
+    /**
+     * Set whether the current object represents a failed authentication
+     * @param isAuthFailed {@code true} if object represents an authentication failure, {@code false}
+     *                                 otherwise
+     */
+    public void setAuthFailed(boolean isAuthFailed) {
+        Log.d(TAG, "Setting isAuthFailed to be " + isAuthFailed);
+        this.isAuthFailed = isAuthFailed;
     }
 
     /**
@@ -273,5 +321,15 @@ public class NetworkResponse<E> {
         Log.d(TAG, "Returning payload=" + payload + ", which is of type=" + type);
         // TODO: This should throw an exception if payload is undefined
         return payload;
+    }
+
+    /**
+     * Get a String representation of the object that conveys the current state of all instance fields
+     * @return String representation of the form {@code NetworkResponse<?>[field1=value1, ...]}
+     */
+    public String toString() {
+        return "NetworkResponse<?>[fail=" + fail + ", messageID=" + messageID + ", payload=" +
+                payloadName(payload) + ", payloadType=" + payloadType(payload) + ", authFail=" +
+                isAuthFailed + "]";
     }
 }

--- a/app/src/main/java/org/codethechange/culturemesh/NetworkResponse.java
+++ b/app/src/main/java/org/codethechange/culturemesh/NetworkResponse.java
@@ -5,11 +5,18 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.support.v7.app.AlertDialog;
+import android.util.Log;
 
 /**
  * Class to store responses after attempting networking tasks
  */
 public class NetworkResponse<E> {
+
+    /**
+     * Tag to use for log statements. It is set dynamically so that if the class name is refactored,
+     * the logging tag will be too.
+     */
+    private static final String TAG = NetworkResponse.class.getSimpleName();
 
     /**
      * Whether or not the network task failed.
@@ -38,6 +45,7 @@ public class NetworkResponse<E> {
      * @param inFail Failure state provided by user (true if failed)
      */
     public NetworkResponse(boolean inFail) {
+        Log.d(TAG, "Creating new NetworkResponse<?> object with inFail=" + inFail);
         fail = inFail;
         if (inFail)
             messageID = R.string.genericFail;
@@ -51,6 +59,8 @@ public class NetworkResponse<E> {
      * @param inMessageID ID for string resource containing message
      */
     public NetworkResponse(boolean inFail, int inMessageID) {
+        Log.d(TAG, "Creating new NetworkResponse<?> object with inFail=" + inFail +
+                ", messageID=" + inMessageID);
         fail = inFail;
         messageID = inMessageID;
     }
@@ -60,6 +70,8 @@ public class NetworkResponse<E> {
      * @param inPayload Payload returned by networking request
      */
     public NetworkResponse(E inPayload) {
+        Log.d(TAG, "Creating new NetworkResponse<?> object with payload=" +
+                payloadName(inPayload) + ", which is of type " + payloadType(inPayload));
         payload = inPayload;
         fail = false;
         messageID = R.string.genericSuccess;
@@ -71,6 +83,8 @@ public class NetworkResponse<E> {
      * @param inPayload Payload returned by networking request
      */
     public NetworkResponse(boolean inFail, E inPayload) {
+        Log.d(TAG, "Creating new NetworkResponse<?> object with inFail=" + inFail +
+                ", payload=" + payloadName(inPayload) + ", which is of type " + payloadType(inPayload));
         payload = inPayload;
         fail = inFail;
         if (inFail)
@@ -85,9 +99,32 @@ public class NetworkResponse<E> {
      * @param inPayload Payload returned by networking request
      */
     public NetworkResponse(boolean inFail, E inPayload, int messageID) {
+        Log.d(TAG, "Creating new NetworkResponse<?> object with inFail=" + inFail +
+                ", payload=" + payloadName(inPayload) + ", which is of type " +
+                payloadType(inPayload) + ", messageID=" + messageID);
         payload = inPayload;
         fail = inFail;
         this.messageID = messageID;
+    }
+
+    private String payloadType(E payload) {
+        String payloadType;
+        if (payload == null) {
+            payloadType = "null";
+        } else {
+            payloadType = payload.getClass().getSimpleName();
+        }
+        return payloadType;
+    }
+
+    private String payloadName(E payload) {
+        String payloadName;
+        if (payload == null) {
+            payloadName = "null";
+        } else {
+            payloadName = payload.toString();
+        }
+        return payloadName;
     }
 
     /**
@@ -99,6 +136,8 @@ public class NetworkResponse<E> {
      * @return NetworkResponse object to describe an authentication failure.
      */
     public static NetworkResponse<API.Get.LoginResponse> getAuthFailed(int messageID) {
+        Log.d(TAG, "Creating new authFailed NetworkResponse<API.Get.LoginResponse> object with " +
+                "messageID=" + messageID);
         NetworkResponse<API.Get.LoginResponse> nr = new NetworkResponse<>(true, messageID);
         nr.isAuthFailed = true;
         return nr;
@@ -109,6 +148,7 @@ public class NetworkResponse<E> {
      * @return true if the request failed, false if it succeeded
      */
     public boolean fail() {
+        Log.d(TAG, "Returning fail=" + fail);
         return fail;
     }
 
@@ -117,6 +157,7 @@ public class NetworkResponse<E> {
      * @return Resource ID of message
      */
     public int getMessageID() {
+        Log.d(TAG, "Returning messageID=" + messageID);
         return messageID;
     }
 
@@ -127,8 +168,10 @@ public class NetworkResponse<E> {
      */
     public AlertDialog getErrorDialog(Context context) {
         if (isAuthFailed) {
+            Log.d(TAG, "Returning an authFailed Error Dialog for context=" + context.getPackageName());
             return genErrorDialog(context, messageID, true);
         } else {
+            Log.d(TAG, "Returning a non-authFailed Error Dialog for context=" + context.getPackageName());
             return genErrorDialog(context, messageID);
         }
     }
@@ -140,6 +183,8 @@ public class NetworkResponse<E> {
      * @return {@link AlertDialog} with specified alert message.
      */
     public static AlertDialog genErrorDialog(Context context, int messageID) {
+        Log.d(TAG, "Generating an Error Dialog for context=" + context.getPackageName() + ", " +
+                "messageID=" + messageID + ". authFail not specified, so it is false");
         return genErrorDialog(context, messageID, false);
     }
 
@@ -153,6 +198,8 @@ public class NetworkResponse<E> {
      * {@link LoginActivity} upon dismissal if {@code authFail} is true.
      */
     public static AlertDialog genErrorDialog(final Context context, int messageID, final boolean authFail) {
+        Log.d(TAG, "Generating an Error Dialog for context=" + context.getPackageName() + ", " +
+                "messageID=" + messageID + ", authFail=" + authFail);
         // SOURCE: https://stackoverflow.com/questions/26097513/android-simple-alert-dialog
         AlertDialog errDialog = new AlertDialog.Builder(context).create();
         errDialog.setTitle(context.getString(R.string.error));
@@ -162,12 +209,15 @@ public class NetworkResponse<E> {
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 if (authFail) {
+                    Log.d(TAG, "Error dialog dismissed, so launching Intent to LoginActivity " +
+                            "and signing user out");
                     Intent toSignIn = new Intent(context, LoginActivity.class);
                     SharedPreferences settings = context.getSharedPreferences(
                             API.SETTINGS_IDENTIFIER, Context.MODE_PRIVATE);
                     LoginActivity.setLoggedOut(settings);
                     context.startActivity(toSignIn);
                 }
+                Log.d(TAG, "Error dialog dismissed");
                 dialog.dismiss();
             }
         };
@@ -182,6 +232,8 @@ public class NetworkResponse<E> {
      * @return {@link AlertDialog} with specified alert message
      */
     public static AlertDialog genSuccessDialog(Context context, int messageID) {
+        Log.d(TAG, "Generating a Success Dialog for context=" + context.getPackageName() + ", " +
+                "messageID=" + messageID);
         // SOURCE: https://stackoverflow.com/questions/26097513/android-simple-alert-dialog
         AlertDialog errDialog = new AlertDialog.Builder(context).create();
         errDialog.setTitle(context.getString(R.string.success));
@@ -202,6 +254,7 @@ public class NetworkResponse<E> {
      * @param context Context upon which to display error dialog
      */
     public void showErrorDialog(Context context) {
+        Log.d(TAG, "Showing error dialog for context=" + context.getPackageName());
         AlertDialog errDialog = getErrorDialog(context);
         errDialog.show();
     }
@@ -211,6 +264,13 @@ public class NetworkResponse<E> {
      * @return Payload returned by network operation
      */
     public E getPayload() {
+        String type = "";
+        if (payload == null) {
+            type = "null";
+        } else {
+            type = payload.getClass().getSimpleName();
+        }
+        Log.d(TAG, "Returning payload=" + payload + ", which is of type=" + type);
         // TODO: This should throw an exception if payload is undefined
         return payload;
     }


### PR DESCRIPTION
When an authentication error is received (401 error when logging in), an error dialog is displayed to the user requesting that they sign in again. When they dismiss it, `LoginActivity` is launched.

To preserve the `isAuthFail` property of `NetworkResponse`s as they propagate up the stack of calls, a new constructor `NetworkResponse(NetworkResponse<?>)` constructor has been added that preserves all qualities of the parameter object except for the payload in the created object. This is now used to pass calls back up the stack.

Resolves #74.