### PR TITLE
Update Join and Leave Network Endpoints

### DIFF
--- a/app/src/main/java/org/codethechange/culturemesh/API.java
+++ b/app/src/main/java/org/codethechange/culturemesh/API.java
@@ -1246,18 +1246,17 @@ class API {
         }
 
         /**
-         * Add a user to an existing network. This operation requires authentication, so the user must
-         * be logged in.
+         * Add the current user to an existing network. This operation requires authentication, so
+         * the user must be logged in.
          * @param queue Queue to which the asynchronous task will be added
-         * @param userId ID of the user to add to the network
          * @param networkId ID of the network to add the user to
          * @param listener Listener whose onResponse method will be called when the operation completes
          */
-        static void addUserToNetwork(final RequestQueue queue, final long userId, final long networkId,
+        static void joinNetwork(final RequestQueue queue, final long networkId,
                                      SharedPreferences settings,
                                      final Response.Listener<NetworkResponse<String>> listener) {
-            emptyModel(queue, API_URL_BASE + "user/" + userId + "/addToNetwork/" + networkId +
-                    "?" + getCredentials(), "API.Post.addUserToNet", settings, listener);
+            emptyModel(queue, API_URL_BASE + "user/joinNetwork/" + networkId +
+                    "?" + getCredentials(), "API.Post.joinNetwork", settings, listener);
         }
 
         // TODO: Document removeUserFromNetwork

--- a/app/src/main/java/org/codethechange/culturemesh/SettingsActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/SettingsActivity.java
@@ -129,7 +129,7 @@ public class SettingsActivity extends DrawerActivity implements NetworkSummaryAd
                                 //Wow! We are removing this network! Sad..
                                 long networkID = ((NetworkSummaryAdapter) rv.getAdapter()).getNetworks()
                                         .get(viewHolder.getAdapterPosition()).id;
-                                API.Post.removeUserFromNetwork(queue, networkID,
+                                API.Post.leaveNetwork(queue, networkID,
                                         getSharedPreferences(API.SETTINGS_IDENTIFIER, MODE_PRIVATE),
                                         new Response.Listener<NetworkResponse<String>>() {
                                     @Override

--- a/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/TimelineActivity.java
@@ -338,7 +338,7 @@ public class TimelineActivity extends DrawerActivity implements DrawerActivity.W
                 @Override
                 public void onClick(View v) {
                     //We need to subscribe this user!
-                    API.Post.addUserToNetwork(queue, currentUser, selectedNetwork,
+                    API.Post.joinNetwork(queue, selectedNetwork,
                             getSharedPreferences(API.SETTINGS_IDENTIFIER, MODE_PRIVATE),
                             new Response.Listener<NetworkResponse<String>>() {
                         @Override


### PR DESCRIPTION
Resolves #81.
Changes:
* Joining now uses new URL without user ID (can only add yourself)
* The leaveNetwork method now uses the DELETE method and a new URL that
excludes the specification of a user ID (since a user can only remove
themselves). To reduce code redundancy, the emptyModel method is now
request-method-agnostic, and can therefore be used for POST, PUT, GET,
etc. requests.
* Documentation has also been added so that all API methods
are documented (some constants remain undocumented).