### PR TITLE
Wrap network name in CreatePostActivity

### DIFF
--- a/app/src/main/java/org/codethechange/culturemesh/CreatePostActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/CreatePostActivity.java
@@ -95,13 +95,13 @@ public class CreatePostActivity extends AppCompatActivity implements
                     Network network = response.getPayload();
                     if (network.isLocationBased()) {
                         networkLabel.setText(getResources().getString(R.string.from) + " " +
-                                network.fromLocation.getListableName() + " " +
+                                network.fromLocation.getFullName() + " " +
                                 getResources().getString(R.string.near) + " " +
-                                network.nearLocation.getListableName());
+                                network.nearLocation.getFullName());
                     } else {
                         networkLabel.setText(network.language.toString() + " " +
                                 getResources().getString(R.string.speakers_in).toString() + " " +
-                                network.nearLocation.getListableName());
+                                network.nearLocation.getFullName());
                     }
                 } else {
                     response.showErrorDialog(CreatePostActivity.this);

--- a/app/src/main/res/layout/content_create_post.xml
+++ b/app/src/main/res/layout/content_create_post.xml
@@ -30,7 +30,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="24dp"
-        android:text="Network:"
+        android:text="@string/network_colon"
         android:textAppearance="@android:style/TextAppearance.Large"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/content_create_post.xml
+++ b/app/src/main/res/layout/content_create_post.xml
@@ -17,12 +17,12 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
         android:ems="10"
-        android:labelFor="@id/create_post_button"
         android:inputType="textNoSuggestions|textMultiLine"
+        android:labelFor="@id/create_post_button"
         app:layout_constraintBottom_toTopOf="@+id/create_post_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/network_label_text" />
+        app:layout_constraintTop_toBottomOf="@+id/network_label" />
 
     <TextView
         android:id="@+id/network_label_text"
@@ -39,11 +39,18 @@
         android:id="@+id/network_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="34dp"
-        android:text="From Indonesia in San Francisco"
-        app:layout_constraintStart_toEndOf="@+id/network_label_text"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_marginEnd="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginStart="@dimen/ui_element_horizontal_spacing"
+        android:layout_marginTop="@dimen/ui_element_vertical_spacing"
+        android:layout_weight="1"
+        android:ellipsize="none"
+        android:maxLines="100"
+        android:scrollHorizontally="false"
+        android:singleLine="false"
+        android:text=""
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/network_label_text" />
 
     <Button
         android:id="@+id/create_post_button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="title_activity_explore_list">ExploreListActivity</string>
     <string name="explore">Explore</string>
     <string name="join_network">Join Network</string>
+    <string name="network_colon">Network:</string>
     <string name="settings">Settings</string>
     <string name="your_communities">Your Communities</string>
     <string name="help_and_feedback">Help and Feedback</string>


### PR DESCRIPTION
Move the network name below the label so it can expand to span the entire window and then
wrap to display long names.

Resolves #118.