### PR TITLE
Stop Back Button from Logging Out After Logging In

### DIFF
--- a/app/src/main/java/org/codethechange/culturemesh/OnboardActivity.java
+++ b/app/src/main/java/org/codethechange/culturemesh/OnboardActivity.java
@@ -125,9 +125,9 @@ public class OnboardActivity extends AhoyOnboarderActivity {
             // User is coming from the login activity
             if (response == Activity.RESULT_OK) {
                 Intent launchNext;
-                SharedPreferences settings = getSharedPreferences(API.SETTINGS_IDENTIFIER, MODE_PRIVATE);
                 launchNext = new Intent(getApplicationContext(), TimelineActivity.class);
                 startActivity(launchNext);
+                finish();
             }
             // else do nothing, as login failed or they did not log in
         }


### PR DESCRIPTION
Before, if the back button was tapped immediately after logging in, the
user would be directed to `OnboardActivity` and forced to login again.
Now, even in this case, the user is sent to `StartActivity`, which would
redirect them to `TimelineActivity` or `ExploreBubblesOpenGLActivity` as
appropriate.

Resolves #127