### PR TITLE
Remove `Welcome` App Icon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,11 +84,6 @@
             android:name=".OnboardActivity"
             android:label="@string/title_activity_onboard"
             android:theme="@style/AppTheme.NoActionBar">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".SpecificPostActivity"


### PR DESCRIPTION
Before, a `Welcome` App was present on the phone's home screen in
addition to the `Culture Mesh` one. The `Welcome` one led to
`OnboardActivity`, while the `Culture Mesh` one led to `StartActivity`.
To remove the `Welcome` one, `OnboardActivity`'s `<intent-filter>`
indicating it was the `MAIN` and `LAUNCHER` activity, was removed from
the manifest.

Resolves #128